### PR TITLE
Typing fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,7 @@ python_requires = >= 3.8
 
 [options.packages.find]
 where = src
+
+[options.package_data]
+perfect_freehand =
+    py.typed


### PR DESCRIPTION
Install the 'py.typed' file to indicate to tools that inline types are available, and put all the parameters and types onto the get_stroke wrapper method. Return concrete types (List) from the function rather than the generic Sequence - any Sequence is still accepted as an input type.